### PR TITLE
Add danish

### DIFF
--- a/CppTranslate/da_danish.h
+++ b/CppTranslate/da_danish.h
@@ -1,0 +1,117 @@
+#pragma once
+// c++ på dansk
+// bare for sjovt
+
+#include <string>
+#include <list>
+#include <cstring>
+#include <vector>
+#define cpp_dansk
+#pragma region anden
+#define benyt using
+#define indgang main
+
+#define __LINJE__ __LINE__
+#define __FIL__ __FILE__
+#pragma endregion
+
+#pragma region operatør
+
+#define typenavn typename
+#define skabelon template
+#define størrelse_af sizeof
+#define operatør operator
+
+#define klasse class
+#define struktur struct
+#define optælling enum
+
+#define konstant const
+#define virtuel virtual
+#define statisk static
+#define på_linjen inline
+
+#define offentlig public
+#define privat private
+#define beskyttet protected
+
+#define type_identifikator typeid
+
+#define kast throw
+#define aflever return
+
+#define ny new
+#define nyt new
+#define slet delete
+#define slet_række delete[]
+
+#define eller or
+#define og and
+#define ikke not
+
+#define sandt true
+#define falsk false
+
+#define lagt_sammen_med +
+#define er =
+#define er_lig_med ==
+#define gange *
+#define fra_trukket -
+#define delt_med /
+
+#define reference(A) (&A)
+#define markør(A) A*
+#define barn_af :
+#define indeks(A) [A]
+
+#define større_end >
+#define mindre_end <
+#define større_eller_lig_med >=
+#define mindre_eller_lig_med <=
+
+#define er_sandt == sandt
+#define er_falsk == falsk
+
+#pragma endregion
+
+#pragma region type
+
+benyt tom = void;
+
+benyt boolsk = bool;
+benyt tegn = char;
+benyt heltal = int;
+benyt flydende = float;
+benyt dobbelt_flydende = double;
+benyt tekststreng = std::string;
+
+benyt nul_termineret_tekststreng = char*;
+
+skabelon<klasse T>
+benyt vektor = std::vector < T>;
+
+skabelon<klasse T>
+benyt liste = std::list<T>;
+
+#pragma endregion
+#pragma region løkker_og_andre
+
+#define hvis if
+#define ellers else
+#define ellers_hvis else if
+#define så_længe while
+//#define for for
+#define for_hver for each
+
+#define mens == så_længe
+#pragma endregion
+
+#pragma region funktioner
+#define skriv printf
+
+#pragma endregion
+
+#define kopier_hukommelse memcpy
+#define sæt_hukommelse memset
+#define længde_af_nul_termineret_tekststreng strlen
+#define kopier_nul_termineret_tekststreng strcpy

--- a/CppTranslate/sample_da.cpp
+++ b/CppTranslate/sample_da.cpp
@@ -1,0 +1,44 @@
+#include "da_danish.h"
+skabelon<klasse t>
+klasse eksempel
+{
+
+};
+
+heltal indgang() 
+{
+	statisk boolsk element er sandt;
+	hvis(element er_falsk)
+	{
+		aflever 1;
+	}
+    nul_termineret_tekststreng p = nyt tegn[10];
+	p indeks(0) er 'c';
+	p indeks(1) er 0;
+	
+    skriv(p);
+
+    aflever 0;
+}
+
+// bad and evil source code:
+
+template<class T>
+class exemple{
+
+};
+
+int main()
+{
+    static bool element = true;
+	if(element == false)
+	{
+		return 1;
+	}
+    char* p = new char[10];
+	p[0] = 'c';
+	p[1] = 0;
+
+    printf(p);
+    return 0;
+}


### PR DESCRIPTION
Adds a rough danish translation, I tried to stick as close to the style of the french translation as possible ie. `char*` is translated as `nul_termineret_tekststreng` instead of simply `c_streng`

Compiles with MSVC 2019 with command `cl /utf-8 sample_da.cpp`