### PR TITLE
Bugfixes of french, spanish and german not compileable with MSVC 2019

### DIFF
--- a/CppTranslate/de_german.h
+++ b/CppTranslate/de_german.h
@@ -29,7 +29,7 @@
 #define geschützt protected
 
 #define werfen throw
-#define zurück return
+#define rückkehr return
 
 #define neu new
 #define löschen delete
@@ -56,6 +56,9 @@
 #define größer_als >
 #define kleiner_als < 
 
+#define ist_wahr == wahr
+#define ist_falsch == falsch
+
 #pragma endregion
 
 #pragma region type
@@ -80,6 +83,7 @@ benutze liste = std::list<T>;
 #pragma region schleife
 
 #define falls if
+#define wenn if
 #define sonst else
 #define sonst_falls else if
 #define während while

--- a/CppTranslate/es_spanish.h
+++ b/CppTranslate/es_spanish.h
@@ -1,14 +1,15 @@
 #pragma once
-// c++ en español
-// sí, es un chiste
+// c++ en espaÃ±ol
+// sÃ­, es un chiste
 
 #include <string>
 #include <list>
 #include <cstring>
 #include <vector>
-#define cpp_español
+#define cpp_espanol
 #pragma region otra
 #define usando using
+#define utilisando using
 #define principal main
 
 #define __LINEA__ __LINE__
@@ -19,7 +20,8 @@
 
 #define nombre_de_tipo typename
 #define plantilla template
-#define tamañode sizeof
+#define grÃ¶ÃŸe_fÃ¼r sizeof
+#define tamaÃ±ode sizeof
 #define operador operator
 
 #define clase class
@@ -28,10 +30,10 @@
 
 #define constante const
 //#define virtual virtual
-#define estático static
-#define enlínea inline
+#define estÃ¡tico static
+#define enlÃ­nea inline
 
-#define público public
+#define pÃºblico public
 #define privado private
 #define protegido protected
 
@@ -62,7 +64,7 @@
 #define referencia_de(A) (&A)
 #define apuntador(A) A*
 #define hijo_de :
-#define índice(A) [A]
+#define Ã­ndice(A) [A]
 
 #define mayor_que >
 #define menor_que <
@@ -76,21 +78,21 @@
 
 #pragma region type
 
-utilisant vacío = void;
+usando vacÃ­o = void;
 
-utilisant booleano = bool;
-utilisant caracter = char;
-utilisant entero = int;
-utilisant flotante = float;
-utilisant doble_flotante = double;
-utilisant frase = std::string;
+usando booleano = bool;
+usando caracter = char;
+usando entero = int;
+usando flotante = float;
+usando doble_flotante = double;
+usando frase = std::string;
 
-utilisant cadena_de_caracteres_que_terminan_en_cero = char*;
+usando cadena_de_caracteres_que_terminan_en_cero = char*;
 
-clase<classe T>
+plantilla<clase T>
 utilisando vector = std::vector < T>;
 
-clase<classe T>
+plantilla<clase T>
 utilisando lista = std::list<T>;
 
 #pragma endregion

--- a/CppTranslate/es_spanish.h
+++ b/CppTranslate/es_spanish.h
@@ -6,7 +6,7 @@
 #include <list>
 #include <cstring>
 #include <vector>
-#define cpp_espanol
+#define cpp_español
 #pragma region otra
 #define usando using
 #define utilisando using

--- a/CppTranslate/fr_french.h
+++ b/CppTranslate/fr_french.h
@@ -53,7 +53,7 @@
 #define faux false
 
 #define additionner +
-#define égal =
+#define est =
 #define égal ==
 #define multiplier *
 #define soustraire -

--- a/CppTranslate/sample_de.cpp
+++ b/CppTranslate/sample_de.cpp
@@ -1,19 +1,18 @@
 #include "de_german.h"
-vorlege<klasse t>
+vorlage<klasse t>
 klasse exemple
 {
 
 };
 
-ganzzahl einstiegspunk
+ganzzahl einstiegspunkt()
 {
-	statisch bool element gleich wenn;
+	statisch bool element gleich wahr;
 	wenn(element ist_falsch)
 	{
 	        rückkehr 1;
-		
 	}
-        satz p = neue zeichen[10];
+	c_satz p = neu zeichen[10];
 	p index(0) gleich 'c';
 	p index(1) gleich 0;
 	
@@ -43,4 +42,3 @@ int main()
     printf(p);
     return 0;
 }
-

--- a/CppTranslate/sample_es.cpp
+++ b/CppTranslate/sample_es.cpp
@@ -1,24 +1,24 @@
 #include "es_spanish.h"
-clase<classe t>
+plantilla<clase t>
 clase ejemplo
 {
 
 };
 
-entero principal() 
+entero principal()
 {
-	est·tico booleano elemento igual verdadero;
-	si(elmento es_falso)
+	est√°tico booleano elemento igual verdadero;
+	si(elemento es_falso)
 	{
 		retornar 1;
 	}
     cadena_de_caracteres_que_terminan_en_cero p = nuevo caracter[10];
-	p Ìndice(0) igual 'c';
-	p Ìndice(1) igual 0;
-	
+	p √≠ndice(0) igual 'c';
+	p √≠ndice(1) igual 0;
+
     escribir(p);
 
-    retourne 0;
+	retornar 0;
 }
 
 // bad and evil source code:

--- a/CppTranslate/sample_fr.cpp
+++ b/CppTranslate/sample_fr.cpp
@@ -5,16 +5,16 @@ classe example
 
 };
 
-intégral point_d_entrée() 
+entier point_d_entrée()
 {
-	statique booléen élément égal vrai;
+	statique booléen élément est vrai;
 	si(élément est_faux)
 	{
 		retourne 1;
 	}
     chaine_de_caractère_c_terminant_par_un_zero p = nouveau charactère[10];
-	p index(0) égal 'c';
-	p index(1) égal 0;
+	p index(0) est 'c';
+	p index(1) est 0;
 	
     écrire(p);
 


### PR DESCRIPTION
First a disclaimer, I don't know these languages and had to rely on google translate.

- The 3 languages should now be compileable with MSVC 2019.
- Fixed missing/wrong translations such as the changes in #6 not being carried over in the sample file.
- Spanish was converted to utf8 encoding to be inline with the other files. 